### PR TITLE
add forcesave option

### DIFF
--- a/controller/callbackcontroller.php
+++ b/controller/callbackcontroller.php
@@ -108,7 +108,9 @@ class CallbackController extends Controller {
         1 => "Editing",
         2 => "MustSave",
         3 => "Corrupted",
-        4 => "Closed"
+        4 => "Closed",
+        6 => "ForceSave",
+        7 => "ForceSaveError"
     );
 
     /**
@@ -330,6 +332,8 @@ class CallbackController extends Controller {
         switch ($trackerStatus) {
             case "MustSave":
             case "Corrupted":
+            case "ForceSave":
+            case "ForceError":
                 if (empty($url)) {
                     $this->logger->info("Track without url: " . $fileId . " status " . $trackerStatus, array("app" => $this->appName));
                     return new JSONResponse(["message" => $this->trans->t("Url not found")], Http::STATUS_BAD_REQUEST);

--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -406,7 +406,10 @@ class EditorController extends Controller {
                 "user" => [
                     "id" => $userId,
                     "name" => $this->userSession->getUser()->getDisplayName()
-                ]
+                ],
+		"customization" => [
+			"forcesave" => $this->config->GetForceSave()
+		]
             ],
             "type" => $type
         ];

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -126,6 +126,7 @@ class SettingsController extends Controller {
             "currentServer" => $this->urlGenerator->getAbsoluteURL("/"),
             "defFormats" => $defFormats,
             "sameTab" => $this->config->GetSameTab(),
+            "forceSave" => $this->config->GetForceSave(),
             "encryption" => $this->checkEncryptionModule()
         ];
         return new TemplateResponse($this->appName, "settings", $data, "blank");
@@ -147,7 +148,8 @@ class SettingsController extends Controller {
                                     $storageUrl,
                                     $secret,
                                     $defFormats,
-                                    $sameTab
+                                    $sameTab,
+                                    $forceSave
                                     ) {
         $this->config->SetDocumentServerUrl($documentserver);
         $this->config->SetDocumentServerInternalUrl($documentserverInternal);
@@ -164,6 +166,7 @@ class SettingsController extends Controller {
 
         $this->config->SetDefaultFormats($defFormats);
         $this->config->SetSameTab($sameTab);
+        $this->config->SetForceSave($forceSave);
 
         if ($this->checkEncryptionModule()) {
             $this->logger->info("SaveSettings when encryption is enabled", array("app" => $this->appName));
@@ -188,7 +191,8 @@ class SettingsController extends Controller {
     public function GetSettings() {
         $result = [
             "formats" => $this->formats(),
-            "sameTab" => $this->config->GetSameTab()
+            "sameTab" => $this->config->GetSameTab(),
+            "forceSave" => $this->config->GetForceSave()
         ];
         return $result;
     }

--- a/js/settings.js
+++ b/js/settings.js
@@ -65,6 +65,7 @@
             });
 
             var sameTab = $("#onlyofficeSameTab").is(":checked");
+            var forceSave = $("#onlyofficeForceSave").is(":checked");
 
             $.ajax({
                 method: "PUT",
@@ -75,7 +76,8 @@
                     storageUrl: onlyofficeStorageUrl,
                     secret: onlyofficeSecret,
                     defFormats: defFormats,
-                    sameTab: sameTab
+                    sameTab: sameTab,
+                    forceSave: forceSave
                 },
                 success: function onSuccess(response) {
                     $(".section-onlyoffice").removeClass("icon-loading");

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -100,6 +100,13 @@ class AppConfig {
     private $_sameTab = "sameTab";
 
     /**
+     * The config key for the setting force save
+     *
+     * @var string
+     */
+    private $_forceSave = "forceSave";
+
+    /**
      * The config key for the verification
      *
      * @var string
@@ -343,6 +350,26 @@ class AppConfig {
      */
     public function GetSameTab() {
         return $this->config->getAppValue($this->appName, $this->_sameTab, "false") === "true";
+    }
+
+    /**
+     * Save the setting force save
+     *
+     * @param boolean $value - force save
+     */
+    public function SetForceSave($value) {
+        $this->logger->info("Set force save: " . $value, array("app" => $this->appName));
+
+        $this->config->setAppValue($this->appName, $this->_forceSave, $value);
+    }
+
+    /**
+     * Get the setting force save
+     *
+     * @return boolean
+     */
+    public function GetForceSave() {
+        return $this->config->getAppValue($this->appName, $this->_forceSave, "false") === "true";
     }
 
     /**

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -63,6 +63,13 @@
     </p>
     <br />
 
+    <p class="onlyoffice-header">
+        <input type="checkbox" class="checkbox" id="onlyofficeForceSave"
+            <?php if ($_["forceSave"]) { ?>checked="checked"<?php } ?> />
+        <label for="onlyofficeForceSave"><?php p($l->t("Upload document to ownCloud when user clicks save in ONLYOFFICE")) ?></label>
+    </p>
+    <br />
+
     <h3 class="onlyoffice-header"><?php p($l->t("The default application for opening the format")) ?></h3>
     <?php foreach ($_["defFormats"] as $format => $setting) { ?>
     <p>


### PR DESCRIPTION
Fixes #116 

This allows for manual saves to ownCloud. For autosave default.json on the Document Server would need to be adjusted as well.

The question for me is whether this should be a config flag or hardcoded as the default.

At least in our case the current behaviour - document is saved only when closed by the last user - lead to quite a bit of confusion until we found the forcesave option. 