### PR TITLE
Allow installation on Nextcloud 14 (master branch)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@
     <screenshot>https://raw.githubusercontent.com/ONLYOFFICE/onlyoffice-owncloud/master/screenshots/settings.png</screenshot>
     <dependencies>
         <owncloud min-version="9.0" max-version="10.0" />
-        <nextcloud min-version="12" max-version="13"/>
+        <nextcloud min-version="12" max-version="14" />
     </dependencies>
     <settings>
         <admin>OCA\Onlyoffice\AdminSettings</admin>


### PR DESCRIPTION
The Nextcloud master branch is on version 14, and upon updating to it yesterday I noticed that it refused to enable the OnlyOffice app because the max-version was too low. I haven't noticed any issues with using the app on the nightly after force-installing it by making this change locally, so I'd like to propose this change in order to add compatibility with Nextcloud 14.