### PR TITLE
Fix settings script breaking other scripts

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -37,6 +37,14 @@
             $("#onlyofficeSecretPanel, #onlyofficeSaveBreak").toggleClass("onlyoffice-hide");
         };
 
+        // This script is loaded on all settings pages, but the elements are only rendered
+        // on the OnlyOffice admin page, therefore there's nothing to do when the expected
+        // elements don't exist.
+        if ($("#onlyofficeInternalUrl").length === 0) {
+            console.info('Cannot start OnlyOffice settings script');
+            return;
+        }
+
         if ($("#onlyofficeInternalUrl").val().length
             || $("#onlyofficeSecret").val().length
             || $("#onlyofficeStorageUrl").val().length) {


### PR DESCRIPTION
The settings script is loaded on all settings section pages, resulting
in other scripts being broken (i.e. app passwords don't load). Hence it
has to be checked whether the expected elements are available.