### PR TITLE
Improved style of error messages that are shown to the user

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -31,6 +31,39 @@
     vertical-align: top;
 }
 
-#iframeEditor.error {
-    color: red;
+.app-onlyoffice {
+    background: #F4F4F4;
 }
+
+.ooErrorContainer {
+    width: 50rem;
+    text-align: center;
+    margin: auto;
+}
+
+.ooErrorContent {
+    display: inline-block;
+    margin-top: 170px;
+    background: #616161;
+    padding: 1rem;
+    border-radius: 5px;
+}
+
+.ooErrorLogo {
+    display: inline-block;
+}
+
+.ooErrorLogo img {
+    width: 2rem;
+}
+
+.ooErrorMessage {
+    display: inline-block;
+    margin-left: 1rem;
+}
+
+.ooErrorMessage p {
+    text-align: left;
+    color: #fff;
+}
+

--- a/js/editor.js
+++ b/js/editor.js
@@ -37,7 +37,16 @@
 
     OCA.Onlyoffice.InitEditor = function () {
         var displayError = function (error) {
-            $("#iframeEditor").text(error).addClass("error");
+            if ($('.ooErrorContainer')) { 
+                $('.ooErrorContainer').remove();
+            }
+            $("<div></div>").addClass('ooErrorContainer').appendTo("#app");
+            $("<div></div>").addClass('ooErrorContent').appendTo(".ooErrorContainer");
+            $("<div></div>").addClass('ooErrorLogo').appendTo(".ooErrorContent");
+            $("<img></img>").attr('src', OC.imagePath('onlyoffice', 'app')).appendTo(".ooErrorLogo");
+            $("<div></div>").addClass('ooErrorMessage').appendTo(".ooErrorContent");
+            $("<p></p>").text("An error occurred:").appendTo(".ooErrorMessage");
+            $("<p></p>").text(error).appendTo(".ooErrorMessage");
         };
 
         var fileId = $("#iframeEditor").data("id");


### PR DESCRIPTION
We use this in our production environment, so I've just made the errors thrown by editor.js a little bit prettier to look at for the end user.

Tested in Chrome, Firefox and Edge.

![image](https://user-images.githubusercontent.com/3529874/48234221-cf180b00-e40c-11e8-9fac-1e3f2bbaf332.png)
