### PR TITLE
Only register action if mimetype is set to default

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -216,16 +216,17 @@
                 if (!config.mime) {
                     return true;
                 }
-                OCA.Files.fileActions.registerAction({
-                    name: "onlyofficeOpen",
-                    displayName: t(OCA.Onlyoffice.AppName, "Open in ONLYOFFICE"),
-                    mime: config.mime,
-                    permissions: OC.PERMISSION_READ,
-                    iconClass: "icon-onlyoffice-open",
-                    actionHandler: OCA.Onlyoffice.FileClick
-                });
 
-                if (config.def) {
+                if(config.def) {
+                    OCA.Files.fileActions.registerAction({
+                        name: "onlyofficeOpen",
+                        displayName: t(OCA.Onlyoffice.AppName, "Open in ONLYOFFICE"),
+                        mime: config.mime,
+                        permissions: OC.PERMISSION_READ,
+                        iconClass: "icon-onlyoffice-open",
+                        actionHandler: OCA.Onlyoffice.FileClick
+                    });
+
                     OCA.Files.fileActions.setDefault(config.mime, "onlyofficeOpen");
                 }
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -122,7 +122,7 @@
             <button id="onlyofficeClearVersionHistory" class="button"><?php p($l->t("Clear")) ?></button>
         </p>
 
-        <p class="onlyoffice-header"><?php p($l->t("The default application for opening the format")) ?></p>
+        <p class="onlyoffice-header"><?php p($l->t("File types associated with ONLYOFFICE")) ?></p>
         <div class="onlyoffice-exts">
             <?php foreach ($_["formats"] as $format => $setting) { ?>
                 <?php if (array_key_exists("mime", $setting)) { ?>


### PR DESCRIPTION
### Description
Since ownCloud 10.7.0 a new context menu for opening files has been introduced https://github.com/owncloud/core/pull/38132. So if you click on a file that mime-type has more than one linked action, a dropdown menu will pop up and you have to choose an app, no matter if the action is default or common action. This is based on the fact, that most apps register their action as a default action, and besides ONLYOFFICE, most apps, don't provide a setting which action should be default or not. 

With this PR it is possible to link a mime-type which should be handled by ONLYOFFICE in general. 
So for example, an admin has files_pdfviewer and onlyoffice-owncloud on an instance running, 
the admin can wether check the 'pdf' in onlyoffice-owncloud setting, which will result in opening the app choose the dropdown menu, or uncheck it, which will result in pdf will be opened in files_pdfviewer directly.


### Fixes
https://github.com/owncloud/enterprise/issues/4634