### PR TITLE
Introduce controller for loading the web-extension js bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ To register the connector, use these lines:
 "external_apps": [
     {
         "id": "onlyoffice",
-        "path": "http(s)://<owncloud-10-server-address>/custom/onlyoffice/js/web/onlyoffice.js",
+        "path": "http(s)://<owncloud-10-server-address>/index.php/apps/onlyoffice/js/onlyoffice.js",
     }
 ]
 ```
+
+Depending on your webserver configuration you can drop the `index.php` segment from the url path.
 
 ## How it works
 

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -32,6 +32,7 @@ use OCA\Onlyoffice\Controller\EditorController;
 use OCA\Onlyoffice\Controller\SettingsApiController;
 use OCA\Onlyoffice\Controller\SettingsController;
 use OCA\Onlyoffice\Controller\TemplateController;
+use OCA\Onlyoffice\Controller\WebAssetController;
 use OCA\Onlyoffice\Crypt;
 use OCA\Onlyoffice\Hookhandler;
 use OCA\Onlyoffice\Hooks;
@@ -217,6 +218,14 @@ class Application extends App {
                 $c->query("AppName"),
                 $c->query("Request"),
                 $c->query("L10N"),
+                $c->query("Logger")
+            );
+        });
+
+        $container->registerService("WebAssetController", function ($c) {
+            return new WebAssetController(
+                $c->query("AppName"),
+                $c->query("Request"),
                 $c->query("Logger")
             );
         });

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -41,6 +41,7 @@ return [
        ["name" => "template#add_template", "url" => "/ajax/template", "verb" => "POST"],
        ["name" => "template#get_templates", "url" => "/ajax/template", "verb" => "GET"],
        ["name" => "template#delete_template", "url" => "/ajax/template", "verb" => "DELETE"],
+       ["name" => "webasset#get", "url" => "/js/onlyoffice.js", "verb" => "GET"],
     ],
     "ocs" => [
         ["name" => "federation#key", "url" => "/api/v1/key", "verb" => "POST"],

--- a/controller/webassetcontroller.php
+++ b/controller/webassetcontroller.php
@@ -23,7 +23,6 @@ use GuzzleHttp\Mimetypes;
 use OC\AppFramework\Http;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDisplayResponse;
-use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\ILogger;

--- a/controller/webassetcontroller.php
+++ b/controller/webassetcontroller.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace OCA\Onlyoffice\Controller;
+
+use GuzzleHttp\Mimetypes;
+use OC\AppFramework\Http;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\ILogger;
+use OCP\IRequest;
+
+/**
+ * Class WebAssetController
+ *
+ * @package OCA\Onlyoffice\Controller
+ */
+class WebAssetController extends Controller {
+
+    /**
+     * @var ILogger
+     */
+    private $logger;
+
+    /**
+     * WebAssetController constructor.
+     *
+     * @param string $AppName - application name
+     * @param IRequest $request - request object
+     * @param ILogger $logger
+     */
+    public function __construct($AppName, IRequest $request, ILogger $logger) {
+        parent::__construct($AppName, $request);
+        $this->logger = $logger;
+    }
+
+    /**
+     * Loads the onlyoffice.js file for integration into ownCloud Web
+     *
+     * @PublicPage
+     * @NoCSRFRequired
+     *
+     * @return Response
+     */
+    public function get(): Response {
+        $basePath = \dirname(__DIR__,1);
+        $filePath = \realpath( $basePath . '/js/web/onlyoffice.js');
+        try {
+            return new DataDisplayResponse(\file_get_contents($filePath), Http::STATUS_OK, [
+                'Content-Type' => $this->getMimeType($filePath),
+                'Content-Length' => \filesize($filePath),
+                'Cache-Control' => 'max-age=0, no-cache, no-store, must-revalidate',
+                'Pragma' => 'no-cache',
+                'Expires' => 'Tue, 24 Sep 1985 22:15:00 GMT',
+                'X-Frame-Options' => 'DENY'
+            ]);
+        } catch(\Exception $e) {
+            $this->logger->logException($e, ['app' => $this->appName]);
+            return new DataResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);
+        }
+    }
+
+    private function getMimeType(string $filename): string {
+        $mimeTypes = Mimetypes::getInstance();
+        return $mimeTypes->fromFilename($filename);
+    }
+}


### PR DESCRIPTION
This PR adds a controller for loading the js bundle for the ownCloud Web extension via ownCloud instead of fetching it via the webserver.

Also updated the `README.md` to reflect the new config for ownCloud web's `config.json`.