### PR TITLE
fix: hardcode js mimetype and remove guzzle import

### DIFF
--- a/controller/webassetcontroller.php
+++ b/controller/webassetcontroller.php
@@ -19,7 +19,6 @@
 
 namespace OCA\Onlyoffice\Controller;
 
-use GuzzleHttp\Mimetypes;
 use OC\AppFramework\Http;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -65,7 +64,7 @@ class WebAssetController extends Controller {
         $filePath = \realpath( $basePath . '/js/web/onlyoffice.js');
         try {
             return new DataDisplayResponse(\file_get_contents($filePath), Http::STATUS_OK, [
-                'Content-Type' => $this->getMimeType($filePath),
+                'Content-Type' => "text/javascript",
                 'Content-Length' => \filesize($filePath),
                 'Cache-Control' => 'max-age=0, no-cache, no-store, must-revalidate',
                 'Pragma' => 'no-cache',
@@ -76,10 +75,5 @@ class WebAssetController extends Controller {
             $this->logger->logException($e, ['app' => $this->appName]);
             return new DataResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
-    }
-
-    private function getMimeType(string $filename): string {
-        $mimeTypes = Mimetypes::getInstance();
-        return $mimeTypes->fromFilename($filename);
     }
 }


### PR DESCRIPTION
The `webassetcontroller` was relying on guzzle to detect the mimetype of a file. Two issues about that:
1. guzzle was upgraded to v7 about half a year ago in ownCloud 10, since then this import was failing and the controller broken.
2. since the file (`onlyoffice.js`) is hardcoded anyway we know the mime type and I don't see a reason against hardcoding the mimetype as well to get rid of the dependency.

This PR is needed to get https://github.com/ONLYOFFICE/onlyoffice-owncloud-web into a working state again.