### PR TITLE
Correct fileId for open and convert Recent files with same names

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -173,7 +173,10 @@
 
     OCA.Onlyoffice.FileClick = function (fileName, context) {
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
-        OCA.Onlyoffice.OpenEditor(fileInfoModel.id, context.dir, fileName);
+        var fileId = context.$file[0].dataset.id || fileInfoModel.id;
+        var winEditor = !fileInfoModel && !OCA.Onlyoffice.setting.sameTab ? document : null;
+
+        OCA.Onlyoffice.OpenEditor(fileId, context.dir, fileName, 0, winEditor);
 
         OCA.Onlyoffice.context = context;
         OCA.Onlyoffice.context.fileName = fileName;
@@ -184,7 +187,7 @@
         var fileList = context.fileList;
 
         var convertData = {
-            fileId: fileInfoModel.id
+            fileId: context.$file[0].dataset.id || fileInfoModel.id
         };
 
         if ($("#isPublic").val()) {


### PR DESCRIPTION
Correct `fileId` for open and convert Recent files with same names