### PR TITLE
default frame height if editors opened in same tab

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -182,7 +182,8 @@
 
                     OCA.Onlyoffice.docEditor = new DocsAPI.DocEditor("iframeEditor", config);
 
-                    if (config.type === "mobile" && $("#app > iframe").css("position") === "fixed") {
+                    if (config.type === "mobile" && $("#app > iframe").css("position") === "fixed"
+                        && !OCA.Onlyoffice.inframe) {
                         $("#app > iframe").css("height", "calc(100% - 45px)");
                     }
 


### PR DESCRIPTION
If editors are open in the **_same tab_**, do not subtract `45px` from the `height`