### PR TITLE
fix: onRequestCompareFile event listener for editors 7.4

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -141,6 +141,7 @@
                         config.events.onRequestInsertImage = OCA.Onlyoffice.onRequestInsertImage;
                         config.events.onRequestMailMergeRecipients = OCA.Onlyoffice.onRequestMailMergeRecipients;
                         config.events.onRequestSelectDocument = OCA.Onlyoffice.onRequestSelectDocument;
+                        config.events.onRequestCompareFile = OCA.Onlyoffice.onRequestSelectDocument; //todo: remove (for editors 7.4)
                         config.events.onRequestSendNotify = OCA.Onlyoffice.onRequestSendNotify;
                         config.events.onRequestReferenceData = OCA.Onlyoffice.onRequestReferenceData;
                         config.events.onRequestOpen = OCA.Onlyoffice.onRequestOpen;


### PR DESCRIPTION
`onRequestCompareFile` event listener for editors 7.4