### PR TITLE
fix: set user avatar as base64

### DIFF
--- a/controller/editorapicontroller.php
+++ b/controller/editorapicontroller.php
@@ -114,13 +114,6 @@ class EditorApiController extends OCSController {
 	private $versionManager;
 
 	/**
-	 * Avatar manager
-	 *
-	 * @var IAvatarManager
-	 */
-	private $avatarManager;
-
-	/**
 	 * Tag manager
 	 *
 	 * @var ITagManager
@@ -174,7 +167,6 @@ class EditorApiController extends OCSController {
 		$this->versionManager = new VersionManager($AppName, $root);
 
 		$this->fileUtility = new FileUtility($AppName, $trans, $logger, $config, $shareManager, $session);
-		$this->avatarManager = \OC::$server->getAvatarManager();
 	}
 
 	/**
@@ -448,19 +440,6 @@ class EditorApiController extends OCSController {
 				"id" => $this->buildUserId($userId),
 				"name" => $user->getDisplayName()
 			];
-			$avatar = $this->avatarManager->getAvatar($userId);
-			if ($avatar->exists()) {
-				$userAvatarUrl = $this->urlGenerator->getAbsoluteURL(
-					$this->urlGenerator->linkToRoute(
-						"core.avatar.getAvatar",
-						[
-							"userId" => $userId,
-							"size" => 64,
-						]
-					)
-				);
-				$params["editorConfig"]["user"]["image"] = $userAvatarUrl;
-			}
 		}
 
 		$folderLink = null;

--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -448,16 +448,7 @@ class EditorController extends Controller {
 					];
 					$avatar = $this->avatarManager->getAvatar($user->getUID());
 					if ($avatar->exists()) {
-						$userAvatarUrl = $this->urlGenerator->getAbsoluteURL(
-							$this->urlGenerator->linkToRoute(
-								"core.avatar.getAvatar",
-								[
-									"userId" => $user->getUID(),
-									"size" => 64,
-								]
-							)
-						);
-						$userData["image"] = $userAvatarUrl;
+						$userData["image"] = "data:image/png;base64," . $avatar->get()->__toString();
 					}
 					array_push($result, $userData);
 				}


### PR DESCRIPTION
1. User avatars are sent as `base64` now
2. Do not set the current user's avatar in the config