### PR TITLE
Owncloud 11 (php 8.3) compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 9.12.2
+## Changed
+- ownCloud 11 (PHP 8.3) compatibility: allow installation on ownCloud 11 (max-version bumped to 11)
+- ownCloud 11 compatibility: support Doctrine DBAL 3 result API in KeyManager and RemoteInstance
+- ownCloud 11 compatibility: int return type for onlyoffice:documentserver occ command (Symfony Console 5+)
+- fix PHP 8.1+ deprecation (rtrim on null) when document server address is not configured
+- fix forcesave status check with native integer DB results on PHP 8.1+
+
 ## 9.12.1
 ## Added
 - plugin description and useful links in admin settings

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,7 +36,7 @@ Moreover, any AI assistant, including local ones, can be effortlessly connected 
     <screenshot>https://raw.githubusercontent.com/ONLYOFFICE/onlyoffice-owncloud/master/screenshots/open.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/ONLYOFFICE/onlyoffice-owncloud/master/screenshots/open_form.png</screenshot>
     <dependencies>
-        <owncloud min-version="10" max-version="10" />
+        <owncloud min-version="10" max-version="11" />
     </dependencies>
     <commands>
         <command>OCA\Onlyoffice\Command\DocumentServer</command>

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -466,7 +466,7 @@ class AppConfig {
 
 		$url = $this->config->getAppValue($this->appName, $this->_documentserver, "");
 		if (empty($url)) {
-			$url = $this->getSystemValue($this->_documentserver);
+			$url = $this->getSystemValue($this->_documentserver) ?? "";
 		}
 		if ($url !== "/") {
 			$url = rtrim($url, "/");

--- a/lib/command/documentserver.php
+++ b/lib/command/documentserver.php
@@ -110,7 +110,7 @@ class DocumentServer extends Command {
 	 *
 	 * @return int 0 if everything went fine, or an exit code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$check = $input->getOption("check");
 
 		$documentserver = $this->config->getDocumentServerUrl(true);

--- a/lib/keymanager.php
+++ b/lib/keymanager.php
@@ -49,7 +49,11 @@ class KeyManager {
 		);
 		$result = $select->execute([$fileId]);
 
-		$keys = $result ? $select->fetch() : [];
+		if ($result instanceof \Doctrine\DBAL\Result) {
+			$keys = $result->fetchAssociative();
+		} else {
+			$keys = $result ? $select->fetch() : [];
+		}
 		$key = \is_array($keys) && isset($keys["key"]) ? $keys["key"] : "";
 
 		return $key;
@@ -152,9 +156,13 @@ class KeyManager {
 		);
 		$result = $select->execute([$fileId]);
 
-		$rows = $result ? $select->fetch() : [];
+		if ($result instanceof \Doctrine\DBAL\Result) {
+			$rows = $result->fetchAssociative();
+		} else {
+			$rows = $result ? $select->fetch() : [];
+		}
 		$fs = \is_array($rows) && isset($rows["fs"]) ? $rows["fs"] : "";
 
-		return $fs === "1";
+		return (string)$fs === "1";
 	}
 }

--- a/lib/remoteinstance.php
+++ b/lib/remoteinstance.php
@@ -68,7 +68,11 @@ class RemoteInstance {
 		);
 		$result = $select->execute([$remote]);
 
-		$dbremote = $result ? $select->fetch() : [];
+		if ($result instanceof \Doctrine\DBAL\Result) {
+			$dbremote = $result->fetchAssociative();
+		} else {
+			$dbremote = $result ? $select->fetch() : [];
+		}
 
 		return $dbremote;
 	}


### PR DESCRIPTION
- allow installation on ownCloud 11 (info.xml max-version 11)
- support Doctrine DBAL 3 result API in KeyManager and RemoteInstance
- add int return type to occ command execute() for Symfony Console 5+
- avoid rtrim(null) deprecation when document server URL is unset
- make forcesave status check type-safe for native int DB results